### PR TITLE
Update CI runners to -latest versions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -36,7 +36,7 @@ jobs:
 
   ensure_cargo_fmt:
     name: Ensure 'cargo fmt' has been run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: dtolnay/rust-toolchain@stable
       with:
@@ -46,7 +46,7 @@ jobs:
 
   min_version:
     name: Minimum supported rust version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: crate_metadata
     steps:
     - name: Checkout source code
@@ -70,18 +70,18 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
-          - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
-          - { target: i686-pc-windows-msvc        , os: windows-2019                  }
-          - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
-          - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-13                      }
-          - { target: aarch64-apple-darwin        , os: macos-15                      }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest, use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest, use-cross: true }
+          - { target: arm-unknown-linux-musleabihf, os: ubuntu-latest, use-cross: true }
+          - { target: i686-pc-windows-msvc        , os: windows-latest                 }
+          - { target: i686-unknown-linux-gnu      , os: ubuntu-latest, use-cross: true }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-latest, use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-13                       }
+          - { target: aarch64-apple-darwin        , os: macos-latest                   }
+          - { target: x86_64-pc-windows-gnu       , os: windows-latest                 }
+          - { target: x86_64-pc-windows-msvc      , os: windows-latest                 }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest, use-cross: true }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest, use-cross: true }
     env:
       BUILD_CMD: cargo
     steps:


### PR DESCRIPTION
This is not ideal practice, but it seems necessary in a lightly-maintained repo like this one to ensure
we're never using runners past their EOL.
