### PR TITLE
docs(readme): simplify fish usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export LS_COLORS="$(vivid generate molokai)"
 or for Fish:
 
 ```fish
-set -gx LS_COLORS "$(vivid generate molokai)"
+set -gx LS_COLORS (vivid generate molokai)
 ```
 
 ### Theme preview


### PR DESCRIPTION
No need to specify global scope when exporting variable, and uses shorter command substitution syntax