### PR TITLE
feat(themes): add Aura theme

### DIFF
--- a/themes/aura-theme-dark-soft.yml
+++ b/themes/aura-theme-dark-soft.yml
@@ -1,0 +1,199 @@
+#
+# Aura Theme > Dark Soft color scheme
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors - Dark Soft variant (desaturated/shaded)
+  accent0: '0f0f0f' # dark accent
+  accent1: '8464c6' # purple (muted)
+  accent2: '54c59f' # green/cyan (muted)
+  accent3: 'c7a06f' # orange (muted)
+  accent4: '7fc557' # lime
+  accent5: 'c55858' # red (muted)
+  accent6: 'c17ac8' # pink (muted)
+  accent7: 'bdbdbd' # foreground (muted)
+  accent8: '6d6d6d' # comments
+  accent32: '6cb2c7' # blue (muted)
+
+  # UI colors
+  accent9: 'b4b4b4' # lighter foreground (softUI variant)
+  accent10: 'adacae' # medium foreground
+  accent13: '2d2d2d' # dark gray (soft-dark variant)
+  accent15: '4d4d4d' # medium gray
+  accent22: '4d466e' # selection
+  accent23: '3b334b' # darker selection
+  accent25: '49c29a' # accent teal
+  accent28: '121016' # darker background
+
+  # Dark Soft darker variants
+  accent11: '000000' # black
+  accent12: '15141b' # background
+  accent21: '110f18' # darker background
+  accent24: '121016' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic

--- a/themes/aura-theme-dark.yml
+++ b/themes/aura-theme-dark.yml
@@ -1,0 +1,199 @@
+#
+# Aura Theme > Dark color scheme
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors
+  accent0: '0f0f0f' # dark accent
+  accent1: 'a277ff' # purple
+  accent2: '61ffca' # green/cyan
+  accent3: 'ffca85' # orange
+  accent4: '9dff65' # lime
+  accent5: 'ff6767' # red
+  accent6: 'f694ff' # pink
+  accent7: 'edecee' # foreground
+  accent8: '6d6d6d' # comments
+  accent32: '82e2ff' # blue
+
+  # UI colors
+  accent9: 'cdccce' # lighter foreground
+  accent10: 'adacae' # medium foreground
+  accent13: '2d2d2d' # dark gray
+  accent15: '4d4d4d' # medium gray
+  accent22: '4d466e' # selection
+  accent23: '3b334b' # darker selection
+  accent25: '49c29a' # accent teal
+  accent28: '121016' # darker background
+
+  # Darker variants
+  accent11: '000000' # black
+  accent12: '15141b' # background
+  accent21: '110f18' # darker background
+  accent24: '121016' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic


### PR DESCRIPTION
### Description

This PR:

- Adds [Aura Theme](https://github.com/daltonmenezes/aura-theme) primary variants
- Templated from existing Tokyo Night - Night theme
- Includes repo and version info in YAML "frontmatter"

### Preview

<img width="1378" height="863" alt="aura-vivid-preview" src="https://github.com/user-attachments/assets/7d5c8eae-3a6b-443d-a5d0-3adcb5eff447" />

### Submitter notes:

- A new build/release will be required to make all of the most recent theme additions bundle into the multiple installation package flavors 

