### PR TITLE
.csv and .tsv are spreadsheet formats, not markup

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -108,14 +108,12 @@ markup:
     - ".1"
     - .aseprite-brushes # Aseprite
     - .aseprite-keys # Aseprite
-    - .csv
     - .markdown
     - .md
     - .mdown
     - .info
     - .org
     - .rst
-    - .tsv
     - .typ
     - .xml
 
@@ -435,9 +433,11 @@ office:
     - .sxw
 
   spreadsheet:
+    - .csv
     - .xls
     - .xlsx
     - .ods
+    - .tsv
     - .xlr
 
   presentation:


### PR DESCRIPTION
.tsv and .csv files are normally opened by a spreadsheet app.

They do not belong with markup extensions like .md and .markdown