### PR TITLE
Fix Keynote presentation ext

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -445,7 +445,7 @@ office:
     - .pptx
     - .odp
     - .sxi
-    - .kex
+    - .key
     - .pps
 
   calendar:


### PR DESCRIPTION
I couldn't find evidence that `.kex` has been used for a presentation file type. `.key` is associated with Apple's Keynote.
