### PR TITLE
Correct spreadsheet types

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -94,6 +94,9 @@ text:
       - passwd
       - shadow
 
+  other:
+    - .txt
+
 markup:
   web:
     - .htm
@@ -449,7 +452,6 @@ office:
   other:
     - .csv
     - .tsv
-    - .txt
 
 archives:
   packages:


### PR DESCRIPTION
`.txt, .csv` can be edited. but `.xls, .ods,` cannot. Create a separate category to enable discrimination if required.

After using the previous version I wanted to color the ones I created using vi different from .ods files created with Libre Office Calc.

It still seems they belong in office, because when I open one, it opens Libre Office Calc.
