### PR TITLE
Add .mjs, .cjs javascript extensions

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -149,7 +149,7 @@ programming:
     haskell: [.hs]
     ipython: [.ipynb]
     java: [.java, .bsh]
-    javascript: [.js, .jsx, .htc]
+    javascript: [.js, .jsx, .htc, .mjs, .cjs]
     julia: [.jl]
     kotlin: [.kt, .kts]
     latex: [.tex, .ltx]


### PR DESCRIPTION
The `.mjs` extension is specifically for JavaScript files that use ECMAScript modules (as opposed to CommonJS).
It's needed if you use ES6 module syntax (import/export) in a project where package.json has `"type": "commonjs"` or no type field.

Both `.mjs` and `.cjs` should be included in the JavaScript extensions list, as they serve specific technical purposes in the Node.js ecosystem.

