### PR TITLE
Upgrade amd64 macos runner to version 15

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -76,7 +76,7 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-latest                 }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-latest, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-latest, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-13                       }
+          - { target: x86_64-apple-darwin         , os: macos-15                       }
           - { target: aarch64-apple-darwin        , os: macos-latest                   }
           - { target: x86_64-pc-windows-gnu       , os: windows-latest                 }
           - { target: x86_64-pc-windows-msvc      , os: windows-latest                 }


### PR DESCRIPTION
The macos-13 runner has been deprecated.
