### PR TITLE
allow hex color codes with leading hash

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -65,6 +65,8 @@ pub enum Ansi3Bit {
 impl Color {
     pub fn from_hex_str(hex_str: &str) -> Result<Color> {
         let parse_error = || VividError::ColorParseError(hex_str.to_string());
+        // Strip the leading '#' if it exists so both 'RRGGBB' and '#RRGGBB' work
+        let hex_str = hex_str.strip_prefix('#').unwrap_or(hex_str);
 
         if hex_str.len() == 6 {
             let r = u8::from_str_radix(&hex_str[0..2], 16).map_err(|_| parse_error())?;
@@ -149,6 +151,15 @@ mod tests {
     fn from_hex_str_3chars() {
         let color = Color::from_hex_str("4ec").unwrap();
         assert_eq!(Color::Rgb(0x44, 0xee, 0xcc), color);
+    }
+
+    #[test]
+    fn from_hex_str_with_hash() {
+        let color = Color::from_hex_str("#4ec703").unwrap();
+        assert_eq!(Color::Rgb(0x4e, 0xc7, 0x03), color);
+
+        let color_short = Color::from_hex_str("#4ec").unwrap();
+        assert_eq!(Color::Rgb(0x44, 0xee, 0xcc), color_short);
     }
 
     #[test]


### PR DESCRIPTION
I've tried various colorizers in vim and Neovim but none will allow me to see the actual colors in my theme file unless the hex color has a leading hash.

<img width="239" height="422" alt="Selenized_colors" src="https://github.com/user-attachments/assets/5884753d-3fa3-40f0-8027-ded1726c2113" />

- It doesn't change any functionality in from_hex_str except to remove a leading # if and only if one exists
- It's only a one line addition to from_hex_str in color.rs
- All tests pass

Any alternate suggestions to render colorized RRGGBB strings are welcome.
