### PR TITLE
Add `--add-filetypes` argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 **/*.rs.bk
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export LS_COLORS="$(vivid generate ansi)"
 ### Customization
 
 Custom [`filetypes.yml` databases](config/filetypes.yml) can be placed in `/usr/share/vivid`, `$HOME/.config/vivid`, or `$XDG_CONFIG_HOME/vivid` on POSIX systems,
-or in `%APPDATA%\vivid` on Windows systems. You can also use the `--add-filetypes` argument to add additional mappings.
+or in `%APPDATA%\vivid` on Windows systems. You can also use the `--add-filetypes` argument to add additional mappings, move existing filetypes into a different category, or remove them by assigning them to the `none` category.
 
 Custom color themes go into a `themes` subfolder, respectively.  You can also specify an explicit path to your custom theme: `vivid generate path/to/my_theme.yml`.
 As a starting point, you can use one of the [bundled themes](themes/).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export LS_COLORS="$(vivid generate ansi)"
 ### Customization
 
 Custom [`filetypes.yml` databases](config/filetypes.yml) can be placed in `/usr/share/vivid`, `$HOME/.config/vivid`, or `$XDG_CONFIG_HOME/vivid` on POSIX systems,
-or in `%APPDATA%\vivid` on Windows systems.
+or in `%APPDATA%\vivid` on Windows systems. You can also use the `--add-filetypes` argument to add additional mappings.
 
 Custom color themes go into a `themes` subfolder, respectively.  You can also specify an explicit path to your custom theme: `vivid generate path/to/my_theme.yml`.
 As a starting point, you can use one of the [bundled themes](themes/).

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -93,6 +93,12 @@ impl FileTypes {
 
         Ok(FileTypes { mapping })
     }
+
+    pub fn merge(&mut self, filetypes: &FileTypes) {
+        for (filetype, category) in filetypes.mapping.iter() {
+            self.mapping.insert(filetype.clone(), category.clone());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +127,39 @@ mod tests {
             vec!["bar".to_string(), "baz".to_string()],
             ft.mapping["*.ext3"]
         );
+    }
+
+    #[test]
+    fn merge() {
+        let mut ft = FileTypes::from_string(
+            "
+                foo:
+                  - .ext1 # Untouched
+                  - .ext2 # To be moved
+                bar:
+                  - .ext3 # Untouched
+            ",
+        )
+        .unwrap();
+
+        let to_merge = FileTypes::from_string(
+            "
+                foo:
+                  - .ext4 # New filetype
+                bar:
+                  - .ext2 # Moved filetype
+                baz:
+                  - .ext5 # New category
+            ",
+        )
+        .unwrap();
+
+        ft.merge(&to_merge);
+
+        assert_eq!(vec!["foo".to_string()], ft.mapping["*.ext1"]);
+        assert_eq!(vec!["bar".to_string()], ft.mapping["*.ext2"]);
+        assert_eq!(vec!["bar".to_string()], ft.mapping["*.ext3"]);
+        assert_eq!(vec!["foo".to_string()], ft.mapping["*.ext4"]);
+        assert_eq!(vec!["baz".to_string()], ft.mapping["*.ext5"]);
     }
 }

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -99,6 +99,11 @@ impl FileTypes {
             self.mapping.insert(filetype.clone(), category.clone());
         }
     }
+
+    pub fn remove_root_category(&mut self, to_remove: &str) {
+        self.mapping
+            .retain(|_, category| category.get(0).is_some_and(|c| c != to_remove));
+    }
 }
 
 #[cfg(test)]
@@ -137,7 +142,7 @@ mod tests {
                   - .ext1 # Untouched
                   - .ext2 # To be moved
                 bar:
-                  - .ext3 # Untouched
+                  - .ext3 # To be removed
             ",
         )
         .unwrap();
@@ -150,16 +155,20 @@ mod tests {
                   - .ext2 # Moved filetype
                 baz:
                   - .ext5 # New category
+                none:
+                  - .ext3 # Removed filetype
             ",
         )
         .unwrap();
 
         ft.merge(&to_merge);
+        ft.remove_root_category("none");
 
         assert_eq!(vec!["foo".to_string()], ft.mapping["*.ext1"]);
         assert_eq!(vec!["bar".to_string()], ft.mapping["*.ext2"]);
-        assert_eq!(vec!["bar".to_string()], ft.mapping["*.ext3"]);
+        assert!(!ft.mapping.contains_key("*.ext3"));
         assert_eq!(vec!["foo".to_string()], ft.mapping["*.ext4"]);
         assert_eq!(vec!["baz".to_string()], ft.mapping["*.ext5"]);
+        assert_eq!(ft.mapping.len(), 4)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,10 @@ fn merge_additional_filetypes(matches: &ArgMatches, filetypes: &mut FileTypes) -
         filetypes.merge(&addition);
     }
 
+    // Remove the "none" category and its descendants, so that existing filetypes
+    // can be excluded from the final output.
+    filetypes.remove_root_category("none");
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,19 @@ fn load_filetypes_database(matches: &ArgMatches, user_config_path: &Path) -> Res
     }
 }
 
+fn merge_additional_filetypes(matches: &ArgMatches, filetypes: &mut FileTypes) -> Result<()> {
+    for path in matches
+        .get_many::<String>("add-filetypes")
+        .unwrap_or_default()
+        .map(Path::new)
+    {
+        let addition = FileTypes::from_path(path)?;
+        filetypes.merge(&addition);
+    }
+
+    Ok(())
+}
+
 fn available_theme_names(user_config_path: &Path) -> Result<Vec<String>> {
     let theme_path_user = user_config_path.join("themes");
     let theme_path_system = PathBuf::from(THEME_PATH_SYSTEM);
@@ -146,6 +159,13 @@ fn cli() -> clap::Command {
                 .value_name("path")
                 .help("Path to filetypes database (filetypes.yml)"),
         )
+        .arg(
+            Arg::new("add-filetypes")
+                .long("add-filetypes")
+                .help("Additional filetypes to add to the database")
+                .action(ArgAction::Append)
+                .value_name("path"),
+        )
         .subcommand(
             Command::new("generate")
                 .about("Generate a LS_COLORS expression")
@@ -175,7 +195,8 @@ fn run() -> Result<()> {
     let basedirs = etcetera::choose_base_strategy().expect("Could not get home directory");
     let user_config_path = basedirs.config_dir().join("vivid");
 
-    let filetypes = load_filetypes_database(&matches, &user_config_path)?;
+    let mut filetypes = load_filetypes_database(&matches, &user_config_path)?;
+    merge_additional_filetypes(&matches, &mut filetypes)?;
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();


### PR DESCRIPTION
This adds an `--add-filetypes` command line argument which lets you add your own mappings to the database. It can be used multiple times.

The main benefit is to be able to reuse the default database if you just want to add a few customizations.

Closes #89
