### PR TITLE
Implement shell completion

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -1,0 +1,56 @@
+_vivid_completions() {
+    local cur prev words cword
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+
+    local themes compshells
+    themes=$(vivid themes 2>/dev/null)
+    compshells=$(vivid completion --list 2>/dev/null)
+
+    local commands="generate preview themes help completion"
+    local global_opts="-m --color-mode -d --database -h --help -V --version"
+
+    local subcmd=""
+    local i
+    for ((i=1; i < cword; i++)); do
+        if [[ ! "${words[i]}" =~ ^- ]]; then
+            subcmd="${words[i]}"
+            break
+        fi
+    done
+
+    case "$prev" in
+        -m|--color-mode)
+            COMPREPLY=( $(compgen -W "8bit 24bit" -- "$cur") )
+            return 0
+            ;;
+        -d|--database)
+            COMPREPLY=( $(compgen -f -- "$cur") ) # Use -f for files
+            return 0
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        local opts="$global_opts"
+        [[ "$subcmd" == "completion" ]] && opts="$opts -l --list"
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    if [[ -z "$subcmd" ]]; then
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    else
+        case "$subcmd" in
+            generate|preview)
+                COMPREPLY=( $(compgen -W "$themes" -- "$cur") )
+                ;;
+            completion)
+                COMPREPLY=( $(compgen -W "$compshells" -- "$cur") )
+                ;;
+        esac
+    fi
+}
+
+complete -F _vivid_completions vivid

--- a/completions/bash
+++ b/completions/bash
@@ -6,17 +6,15 @@ _vivid_completions() {
     cword=$COMP_CWORD
 
     local themes compshells
-    themes=$(vivid themes 2>/dev/null)
-    compshells=$(vivid completion --list 2>/dev/null)
-
     local commands="generate preview themes help completion"
-    local global_opts="-m --color-mode -d --database -h --help -V --version"
-
+    
     local subcmd=""
+    local subcmd_index=0
     local i
     for ((i=1; i < cword; i++)); do
         if [[ ! "${words[i]}" =~ ^- ]]; then
             subcmd="${words[i]}"
+            subcmd_index=$i
             break
         fi
     done
@@ -27,26 +25,42 @@ _vivid_completions() {
             return 0
             ;;
         -d|--database)
-            COMPREPLY=( $(compgen -f -- "$cur") ) # Use -f for files
+            COMPREPLY=( $(compgen -f -- "$cur") )
             return 0
             ;;
     esac
 
     if [[ "$cur" == -* ]]; then
-        local opts="$global_opts"
-        [[ "$subcmd" == "completion" ]] && opts="$opts -l --list"
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        if [[ -z "$subcmd" ]]; then
+            COMPREPLY=( $(compgen -W "-m --color-mode -d --database -h --help -V --version" -- "$cur") )
+        else
+            case "$subcmd" in
+                completion)
+                    COMPREPLY=( $(compgen -W "-l --list -h --help" -- "$cur") )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+                    ;;
+            esac
+        fi
         return 0
     fi
 
     if [[ -z "$subcmd" ]]; then
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     else
+        if [[ $cword -gt $((subcmd_index + 1)) ]]; then
+            COMPREPLY=()
+            return 0
+        fi
+
         case "$subcmd" in
             generate|preview)
+                themes=$(vivid themes 2>/dev/null)
                 COMPREPLY=( $(compgen -W "$themes" -- "$cur") )
                 ;;
             completion)
+                compshells=$(vivid completion --list 2>/dev/null)
                 COMPREPLY=( $(compgen -W "$compshells" -- "$cur") )
                 ;;
         esac

--- a/completions/zsh
+++ b/completions/zsh
@@ -1,0 +1,40 @@
+#compdef vivid
+
+local -a themes
+themes=($(vivid themes 2>/dev/null))
+local -a compshells
+compshells=($(vivid completion --list 2>/dev/null))
+
+_arguments -s \
+    '(-m --color-mode)'{-m,--color-mode}'[Type of ANSI colors]:mode:(8bit 24bit)' \
+    '(-d --database)'{-d,--database}'[Path to filetypes database]:file:_files' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '(-V --version)'{-V,--version}'[Show version]' \
+    '1: :->cmds' \
+    '*:: :->args'
+
+case $state in
+    cmds)
+        local -a subcmds
+        subcmds=(
+            'generate:Generate a LS_COLORS expression'
+            'preview:Preview a given theme'
+            'themes:List available themes'
+            'help:Show help'
+            'completion:Get shell completion script'
+        )
+        _describe -t commands 'vivid command' subcmds
+        ;;
+    args)
+        case $words[1] in
+            generate|preview)
+                _values 'themes' "${themes[@]}"
+                ;;
+            completion)
+                _arguments -s \
+                    '(-l --list)'{-l,--list}'[List supported shells]'
+                _values 'compshells' "${compshells[@]}"
+                ;;
+        esac
+        ;;
+esac

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -24,3 +24,9 @@ pub fn get_completion_as_str(sh: &str) -> Result<String> {
         })?;
     Ok(contents.to_string())
 }
+
+pub fn get_available_completion_files() -> Vec<String> {
+    CompletionAssets::iter()
+        .map(|path| path.into_owned())
+        .collect()
+}

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -12,16 +12,13 @@ struct CompletionAssets;
 
 pub fn get_completion_as_str(sh: &str) -> Result<String> {
     let completion_file = CompletionAssets::get(sh)
-        .ok_or_else(|| {
-            VividError::CouldNotFindCompletionFile(sh.to_string())
-        })?;
-    let contents = std::str::from_utf8(&completion_file.data)
-        .map_err(|_| {
-            VividError::IoError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Completion file '{}' is not valid UTF-8.", sh))
-            )
-        })?;
+        .ok_or_else(|| VividError::CouldNotFindCompletionFile(sh.to_string()))?;
+    let contents = std::str::from_utf8(&completion_file.data).map_err(|_| {
+        VividError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Completion file '{}' is not valid UTF-8.", sh),
+        ))
+    })?;
     Ok(contents.to_string())
 }
 

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,0 +1,26 @@
+use rust_embed::RustEmbed;
+
+use crate::error::{Result, VividError};
+
+/*
+    Naming convention: completions/[shell name]
+    For example: completions/bash
+*/
+#[derive(RustEmbed)]
+#[folder = "completions/"]
+struct CompletionAssets;
+
+pub fn get_completion_as_str(sh: &str) -> Result<String> {
+    let completion_file = CompletionAssets::get(sh)
+        .ok_or_else(|| {
+            VividError::CouldNotFindCompletionFile(sh.to_string())
+        })?;
+    let contents = std::str::from_utf8(&completion_file.data)
+        .map_err(|_| {
+            VividError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Completion file '{}' is not valid UTF-8.", sh))
+            )
+        })?;
+    Ok(contents.to_string())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum VividError {
     CouldNotFindStyleFor(String),
     UnknownColor(String),
     InvalidFileName(String),
+    NoCompletionShellProvided,
+    CouldNotFindCompletionFile(String),
 }
 
 impl Display for VividError {
@@ -49,6 +51,14 @@ impl Display for VividError {
             VividError::InvalidFileName(file_name) => {
                 write!(fmt, "Invalid file name '{}'", file_name)
             }
+            VividError::NoCompletionShellProvided => write!(
+                fmt,
+                "Argument not optional: [shell]. Try `vivid completion --shells` for a list"
+            ),
+            VividError::CouldNotFindCompletionFile(file_name) => write!(
+                fmt,
+                "Could not find completion file '{}'.", file_name
+            ),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,10 +55,9 @@ impl Display for VividError {
                 fmt,
                 "Argument not optional: [shell]. Try `vivid completion --list` for a list"
             ),
-            VividError::CouldNotFindCompletionFile(file_name) => write!(
-                fmt,
-                "Could not find completion file '{}'.", file_name
-            ),
+            VividError::CouldNotFindCompletionFile(file_name) => {
+                write!(fmt, "Could not find completion file '{}'.", file_name)
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ impl Display for VividError {
             }
             VividError::NoCompletionShellProvided => write!(
                 fmt,
-                "Argument not optional: [shell]. Try `vivid completion --shells` for a list"
+                "Argument not optional: [shell]. Try `vivid completion --list` for a list"
             ),
             VividError::CouldNotFindCompletionFile(file_name) => write!(
                 fmt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 mod color;
+mod completion;
 mod error;
 mod filetypes;
 mod font_style;
 mod theme;
 mod types;
 mod util;
-mod completion;
 
 use etcetera::BaseStrategy;
 use rust_embed::RustEmbed;
@@ -19,10 +19,10 @@ use clap::{
 };
 
 use crate::color::ColorMode;
+use crate::completion::{get_available_completion_files, get_completion_as_str};
 use crate::error::{Result, VividError};
 use crate::filetypes::FileTypes;
 use crate::theme::Theme;
-use crate::completion::{get_completion_as_str, get_available_completion_files};
 
 #[derive(RustEmbed)]
 #[folder = "themes/"]
@@ -166,18 +166,20 @@ fn cli() -> clap::Command {
         )
         .subcommand(Command::new("themes").about("Prints list of available themes"))
         .subcommand(
-            Command::new("completion").about("Get shell completion").arg(
-                Arg::new("shell")
-                    .help("Name of the shell")
-                    .action(ArgAction::Set)
-            )
-            .arg(
-                Arg::new("list")
-                    .long("list")
-                    .short('l')
-                    .action(ArgAction::SetTrue)
-                    .help("List available completion files"),
-            ),
+            Command::new("completion")
+                .about("Get shell completion")
+                .arg(
+                    Arg::new("shell")
+                        .help("Name of the shell")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("list")
+                        .long("list")
+                        .short('l')
+                        .action(ArgAction::SetTrue)
+                        .help("List available completion files"),
+                ),
         )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use crate::color::ColorMode;
 use crate::error::{Result, VividError};
 use crate::filetypes::FileTypes;
 use crate::theme::Theme;
-use crate::completion::{get_completion_as_str};
+use crate::completion::{get_completion_as_str, get_available_completion_files};
 
 #[derive(RustEmbed)]
 #[folder = "themes/"]
@@ -170,6 +170,13 @@ fn cli() -> clap::Command {
                 Arg::new("shell")
                     .help("Name of the shell")
                     .action(ArgAction::Set)
+            )
+            .arg(
+                Arg::new("list")
+                    .long("list")
+                    .short('l')
+                    .action(ArgAction::SetTrue)
+                    .help("List available completion files"),
             ),
         )
 }
@@ -231,9 +238,14 @@ fn run() -> Result<()> {
             writeln!(stdout_lock, "{}", theme).ok();
         }
     } else if let Some(submatches) = matches.subcommand_matches("completion") {
-        if let Some(shell) = submatches.get_one::<String>("shell") {
+        if matches!(submatches.get_one::<bool>("list"), Some(true)) {
+            let compfiles = get_available_completion_files();
+            for file in compfiles {
+                writeln!(stdout_lock, "{}", file).ok();
+            }
+        } else if let Some(shell) = submatches.get_one::<String>("shell") {
             let comp = get_completion_as_str(&shell)?; // Result
-            print!("{}", comp);
+            write!(stdout_lock, "{}", comp).ok();
         } else {
             return Err(VividError::NoCompletionShellProvided);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod font_style;
 mod theme;
 mod types;
 mod util;
+mod completion;
 
 use etcetera::BaseStrategy;
 use rust_embed::RustEmbed;
@@ -21,6 +22,7 @@ use crate::color::ColorMode;
 use crate::error::{Result, VividError};
 use crate::filetypes::FileTypes;
 use crate::theme::Theme;
+use crate::completion::{get_completion_as_str};
 
 #[derive(RustEmbed)]
 #[folder = "themes/"]
@@ -163,6 +165,13 @@ fn cli() -> clap::Command {
             ),
         )
         .subcommand(Command::new("themes").about("Prints list of available themes"))
+        .subcommand(
+            Command::new("completion").about("Get shell completion").arg(
+                Arg::new("shell")
+                    .help("Name of the shell")
+                    .action(ArgAction::Set)
+            ),
+        )
 }
 
 fn run() -> Result<()> {
@@ -220,6 +229,13 @@ fn run() -> Result<()> {
     } else if matches.subcommand_matches("themes").is_some() {
         for theme in available_theme_names(&user_config_path)? {
             writeln!(stdout_lock, "{}", theme).ok();
+        }
+    } else if let Some(submatches) = matches.subcommand_matches("completion") {
+        if let Some(shell) = submatches.get_one::<String>("shell") {
+            let comp = get_completion_as_str(&shell)?; // Result
+            print!("{}", comp);
+        } else {
+            return Err(VividError::NoCompletionShellProvided);
         }
     }
     Ok(())


### PR DESCRIPTION
Relates #86

Add directory `completions` containing the completion scripts.

Add subcommand `completion` with option [shell] or [-l,--list].

Example: `vivid completion bash`
```output
[Content of completions/bash (embedded at build time)]
```

The completion scripts may need reviews.